### PR TITLE
Added curly braces on the methods array function call

### DIFF
--- a/src/ShapeFile.php
+++ b/src/ShapeFile.php
@@ -144,7 +144,7 @@ class ShapeFile
             25  => 'readPolygonM',
             28  => 'readMultiPointM'
         );
-        $shp = $this->$methods[$shape_type]();
+        $shp = $this->{$methods[$shape_type]}();
         
         if ($geometry_format == self::GEOMETRY_WKT)  $shp = $this->toWKT($shp);
         if ($geometry_format == self::GEOMETRY_BOTH) $shp['wkt'] = $this->toWKT($shp);


### PR DESCRIPTION
To explicitly use the right evaluation order. (wasn't working with PHP7)

Forwards compatible with PHP 7.x and backwards compatible with PHP 5.x (see https://github.com/tpunt/PHP7-Reference#uniform-variable-syntax)