### PR TITLE
Normalized class name in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "autoload": {
         "psr-4": {
-            "ShapeFile\\": "src/"
+            "Shapefile\\": "src/"
         }
     }
 }


### PR DESCRIPTION
Couldn't `composer require` the branch since the new normalized class names clashed with the `composer.json` definition.

Single char diffs FTW!