### PR TITLE
Fix : using false as a value for DBF_TYPE_LOGICAL field

### DIFF
--- a/src/Shapefile/ShapefileWriter.php
+++ b/src/Shapefile/ShapefileWriter.php
@@ -965,7 +965,7 @@ class ShapefileWriter extends Shapefile
             case Shapefile::DBF_TYPE_LOGICAL:
                 if ($value === null) {
                     $value = Shapefile::DBF_VALUE_NULL;
-                } elseif ($value === true || strpos(Shapefile::DBF_VALUE_MASK_TRUE, substr(trim($value), 0, 1)) !== false) {
+                } elseif ($value === true || (strlen(trim($value)) > 0 && strpos(Shapefile::DBF_VALUE_MASK_TRUE, substr(trim($value), 0, 1)) !== false)) {
                     $value = Shapefile::DBF_VALUE_TRUE;
                 } else {
                     $value = Shapefile::DBF_VALUE_FALSE;


### PR DESCRIPTION
Fix : using false as a value for DBF_TYPE_LOGICAL field generate a warning in PHP 7