### PR TITLE
Add field name in ShapeFileException

### DIFF
--- a/src/Shapefile/Shapefile.php
+++ b/src/Shapefile/Shapefile.php
@@ -1269,7 +1269,7 @@ abstract class Shapefile
         }
         // Check filed count
         if (count($this->fields) >= Shapefile::DBF_MAX_FIELD_COUNT) {
-            throw new ShapefileException(Shapefile::ERR_DBF_MAX_FIELD_COUNT_REACHED, Shapefile::DBF_MAX_FIELD_COUNT);
+            throw new ShapefileException(Shapefile::ERR_DBF_MAX_FIELD_COUNT_REACHED, Shapefile::DBF_MAX_FIELD_COUNT, $name);
         }
         
         // Sanitize name and normalize case
@@ -1284,7 +1284,7 @@ abstract class Shapefile
             &&  $type !== Shapefile::DBF_TYPE_NUMERIC
             &&  $type !== Shapefile::DBF_TYPE_FLOAT
         ) {
-            throw new ShapefileException(Shapefile::ERR_DBF_FIELD_TYPE_NOT_VALID, "$name - $type");
+            throw new ShapefileException(Shapefile::ERR_DBF_FIELD_TYPE_NOT_VALID, "$name - $type", $name);
         }
         
         // Check size
@@ -1299,7 +1299,7 @@ abstract class Shapefile
             ||  ($type == Shapefile::DBF_TYPE_NUMERIC && $size > $max_size)
             ||  ($type == Shapefile::DBF_TYPE_FLOAT && $size > $max_size)
         ) {
-            throw new ShapefileException(Shapefile::ERR_DBF_FIELD_SIZE_NOT_VALID, "$name - $type - $size");
+            throw new ShapefileException(Shapefile::ERR_DBF_FIELD_SIZE_NOT_VALID, "$name - $type - $size", $name);
         }
         
         // Minimal decimal formal check
@@ -1310,7 +1310,7 @@ abstract class Shapefile
             ||  ($decimals < 0)
             ||  ($decimals > 0 && $size - 1 <= $decimals)
         ) {
-            throw new ShapefileException(Shapefile::ERR_DBF_FIELD_DECIMALS_NOT_VALID, "$name - $type - $decimals");
+            throw new ShapefileException(Shapefile::ERR_DBF_FIELD_DECIMALS_NOT_VALID, "$name - $type - $decimals", $name);
         }
         
         // Add field

--- a/src/Shapefile/ShapefileException.php
+++ b/src/Shapefile/ShapefileException.php
@@ -28,9 +28,9 @@ class ShapefileException extends \Exception
     private $details;
 
     /**
-     * @var string The field where the error was raised if appropriate
+     * @var string      The field where the error was raised if appropriate
      */
-    private string $field = '';
+    private $field = '';
     
     
     /**

--- a/src/Shapefile/ShapefileException.php
+++ b/src/Shapefile/ShapefileException.php
@@ -26,6 +26,11 @@ class ShapefileException extends \Exception
      * @var string      Additional information about the error.
      */
     private $details;
+
+    /**
+     * @var string The field where the error was raised if relevant
+     */
+    private string $field = '';
     
     
     /**
@@ -34,10 +39,11 @@ class ShapefileException extends \Exception
      * @param   string  $error_type     Error type.
      * @param   string  $details        Optional information about the error.
      */
-    public function __construct($error_type, $details = '')
+    public function __construct($error_type, $details = '', $field = '')
     {
         $this->error_type   = $error_type;
         $this->details      = $details;
+        $this->field        = $field;
         
         $message = constant('Shapefile\Shapefile::' . $error_type . '_MESSAGE');
         parent::__construct($message, 0, null);
@@ -61,5 +67,15 @@ class ShapefileException extends \Exception
     public function getDetails()
     {
         return $this->details;
+    }
+
+    /**
+     * Gets field name if revelant, empty string otherwise
+     *
+     * @return  string
+     */
+    public function getField()
+    {
+        return $this->field;
     }
 }

--- a/src/Shapefile/ShapefileException.php
+++ b/src/Shapefile/ShapefileException.php
@@ -28,7 +28,7 @@ class ShapefileException extends \Exception
     private $details;
 
     /**
-     * @var string The field where the error was raised if relevant
+     * @var string The field where the error was raised if appropriate
      */
     private string $field = '';
     
@@ -70,7 +70,7 @@ class ShapefileException extends \Exception
     }
 
     /**
-     * Gets field name if revelant, empty string otherwise
+     * Gets field name if appropriate, empty string otherwise
      *
      * @return  string
      */


### PR DESCRIPTION
- New attribute 'field' in the ShapefileException to be able to store the field name
- New Getter to get this 'name' field and be able to provide a better error message when an user load an incorrect shapefile
- Modify the throwing of exceptions in the 'addField' method to store the field name when an error occur