### PR TITLE
PHP8.4 Deprecation fix

### DIFF
--- a/src/Shapefile/Geometry/GeometryCollection.php
+++ b/src/Shapefile/Geometry/GeometryCollection.php
@@ -45,7 +45,7 @@ abstract class GeometryCollection extends Geometry
      *
      * @param   \Shapefile\Geometry\Geometry[]  $geometries     Optional array of geometries to initialize the collection.
      */
-    public function __construct(array $geometries = null)
+    public function __construct(array $geometries = [])
     {
         if ($geometries !== null) {
             foreach ($geometries as $Geometry) {

--- a/src/Shapefile/Geometry/MultiPolygon.php
+++ b/src/Shapefile/Geometry/MultiPolygon.php
@@ -91,7 +91,7 @@ class MultiPolygon extends GeometryCollection
      *                                                                  - Shapefile::ORIENTATION_COUNTERCLOCKWISE
      *                                                                  - Shapefile::ORIENTATION_UNCHANGED
      */
-    public function __construct(array $polygons = null, $closed_rings = Shapefile::ACTION_CHECK, $force_orientation = Shapefile::ORIENTATION_COUNTERCLOCKWISE)
+    public function __construct(array $polygons = [], $closed_rings = Shapefile::ACTION_CHECK, $force_orientation = Shapefile::ORIENTATION_COUNTERCLOCKWISE)
     {
         $this->closed_rings         = $closed_rings;
         $this->force_orientation    = $force_orientation;

--- a/src/Shapefile/Geometry/MultiPolygon.php
+++ b/src/Shapefile/Geometry/MultiPolygon.php
@@ -109,7 +109,7 @@ class MultiPolygon extends GeometryCollection
             if (!isset($part['rings']) || !is_array($part['rings'])) {
                 throw new ShapefileException(Shapefile::ERR_INPUT_ARRAY_NOT_VALID);
             }
-            $Polygon = new Polygon(null, $this->closed_rings, $this->force_orientation);
+            $Polygon = new Polygon([], $this->closed_rings, $this->force_orientation);
             foreach ($part['rings'] as $part) {
                 if (!isset($part['points']) || !is_array($part['points'])) {
                     throw new ShapefileException(Shapefile::ERR_INPUT_ARRAY_NOT_VALID);
@@ -135,7 +135,7 @@ class MultiPolygon extends GeometryCollection
             $force_z = $this->wktIsZ($wkt);
             $force_m = $this->wktIsM($wkt);
             foreach (explode(')),((', substr($this->wktExtractData($wkt), 2, -2)) as $part) {
-                $Polygon = new Polygon(null, $this->closed_rings, $this->force_orientation);
+                $Polygon = new Polygon([], $this->closed_rings, $this->force_orientation);
                 foreach (explode('),(', $part) as $ring) {
                     $Linestring = new Linestring();
                     foreach (explode(',', $ring) as $wkt_coordinates) {
@@ -160,7 +160,7 @@ class MultiPolygon extends GeometryCollection
                 if (!is_array($part)) {
                     throw new ShapefileException(Shapefile::ERR_INPUT_GEOJSON_NOT_VALID, 'Wrong coordinates format');
                 }
-                $Polygon = new Polygon(null, $this->closed_rings, $this->force_orientation);
+                $Polygon = new Polygon([], $this->closed_rings, $this->force_orientation);
                 foreach ($part as $ring) {
                     if (!is_array($ring)) {
                         throw new ShapefileException(Shapefile::ERR_INPUT_GEOJSON_NOT_VALID, 'Wrong coordinates format');

--- a/src/Shapefile/Geometry/Polygon.php
+++ b/src/Shapefile/Geometry/Polygon.php
@@ -84,7 +84,7 @@ class Polygon extends MultiLinestring
      *                                                                      - Shapefile::ORIENTATION_COUNTERCLOCKWISE
      *                                                                      - Shapefile::ORIENTATION_UNCHANGED
      */
-    public function __construct(array $linestrings = null, $closed_rings = Shapefile::ACTION_CHECK, $force_orientation = Shapefile::ORIENTATION_COUNTERCLOCKWISE)
+    public function __construct(array $linestrings = [], $closed_rings = Shapefile::ACTION_CHECK, $force_orientation = Shapefile::ORIENTATION_COUNTERCLOCKWISE)
     {
         $this->closed_rings         = $closed_rings;
         $this->force_orientation    = $force_orientation;

--- a/src/Shapefile/ShapefileReader.php
+++ b/src/Shapefile/ShapefileReader.php
@@ -974,7 +974,7 @@ class ShapefileReader extends Shapefile implements \Iterator
      */
     private function createPolygon($data)
     {
-        $MultiPolygon   = new MultiPolygon(null, $this->getOption(Shapefile::OPTION_POLYGON_CLOSED_RINGS_ACTION), $this->getOption(Shapefile::OPTION_POLYGON_OUTPUT_ORIENTATION));
+        $MultiPolygon   = new MultiPolygon([], $this->getOption(Shapefile::OPTION_POLYGON_CLOSED_RINGS_ACTION), $this->getOption(Shapefile::OPTION_POLYGON_OUTPUT_ORIENTATION));
         $Polygon        = null;
         $temp_state     = null;
         foreach ($data['geometry']['parts'] as $part) {
@@ -988,7 +988,7 @@ class ShapefileReader extends Shapefile implements \Iterator
                 if ($Polygon !== null) {
                     $MultiPolygon->addPolygon($Polygon);
                 }
-                $Polygon    = new Polygon(null, $this->getOption(Shapefile::OPTION_POLYGON_CLOSED_RINGS_ACTION), $this->getOption(Shapefile::OPTION_POLYGON_OUTPUT_ORIENTATION));
+                $Polygon    = new Polygon([], $this->getOption(Shapefile::OPTION_POLYGON_CLOSED_RINGS_ACTION), $this->getOption(Shapefile::OPTION_POLYGON_OUTPUT_ORIENTATION));
                 $temp_state = $is_clockwise;
             }
             $Polygon->addRing($Linestring);


### PR DESCRIPTION
Fixes PHP 8.4 deprecation warnings/errors

I first tried array|null and ?array but they were added in PHP8.0 and PHP7.1 respectively. So I reviewed what happens with the null and it just gets ignored with the if. I think this fix should work with 5.4.

```
Shapefile\Geometry\MultiPolygon::__construct(): Implicitly marking parameter $polygons as nullable is deprecated, the explicit nullable type must be used instead
Shapefile\Geometry\GeometryCollection::__construct(): Implicitly marking parameter $geometries as nullable is deprecated, the explicit nullable type must be used instead
Shapefile\Geometry\MultiPolygon::__construct(): Implicitly marking parameter $polygons as nullable is deprecated, the explicit nullable type must be used instead
```